### PR TITLE
Rebind Keys and support rapid fire

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -107,6 +107,7 @@
         <script type="text/javascript">
             window.addEventListener('keydown', function(e)
             {
+                // ensure that hitting space on the page does not scroll down
                 if(e.keyCode == 32 && e.target == document.body)
                 {
                     e.preventDefault();

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -125,9 +125,9 @@
             <div id="controls">
                 <h2>Controls</h2>
                 <ul>
-                    <li>WASD - Movement, Up to Jump (You can double jump)</li>
-                    <li>Space - Fire Squirt Gun</li>
-                    <li>F - Throw Water Balloon</li>
+                    <li>WASD - Movement (A and D are the only ones that do anything)</li>
+                    <li>J (Hold) - Fire Squirt Gun</li>
+                    <li>K (Click) - Throw Water Balloon</li>
                 </ul>
             </div>
 

--- a/public_html/src/MyGame/Objects/Hobbes.js
+++ b/public_html/src/MyGame/Objects/Hobbes.js
@@ -69,6 +69,7 @@ function Hobbes(spriteSheet, posX, posY) {
     //Water balloon and timer
     this.mHasBalloon = true;
     this.balloonTimer = null;
+    this.squirtGunTimer = 0;
 }
 gEngine.Core.inheritPrototype(Hobbes, GameObject);
 
@@ -210,22 +211,26 @@ Hobbes.prototype.update = function(
     }
     
     // Fire squirt gun shots
-    if (gEngine.Input.isKeyClicked(gEngine.Input.keys.J)) {
-        if (this.mFacing === this.eFacing.left) {
-            var xPos = this.getXform().getPosition()[0] - 5;
-            var yPos = this.getXform().getPosition()[1] +
-                       (this.getXform().getHeight() / 4);
-            var shot = new SquirtGunShot(
-                squirtGunShotSprite, xPos, yPos, true);
-            squirtGunShots.addToSet(shot);
-        }
-        else { // facing right
-            var xPos = this.getXform().getPosition()[0] + 5;
-            var yPos = this.getXform().getPosition()[1] +
-                       (this.getXform().getHeight() / 4);
-            var shot = new SquirtGunShot(
-                squirtGunShotSprite, xPos, yPos, false);
-            squirtGunShots.addToSet(shot);
+    if (gEngine.Input.isKeyPressed(gEngine.Input.keys.J)) {
+
+        if(Date.now() - this.squirtGunTimer >= 150) {
+            this.squirtGunTimer = Date.now();
+            if (this.mFacing === this.eFacing.left) {
+                var xPos = this.getXform().getPosition()[0] - 5;
+                var yPos = this.getXform().getPosition()[1] +
+                    (this.getXform().getHeight() / 4);
+                var shot = new SquirtGunShot(
+                    squirtGunShotSprite, xPos, yPos, true);
+                squirtGunShots.addToSet(shot);
+            }
+            else { // facing right
+                var xPos = this.getXform().getPosition()[0] + 5;
+                var yPos = this.getXform().getPosition()[1] +
+                    (this.getXform().getHeight() / 4);
+                var shot = new SquirtGunShot(
+                    squirtGunShotSprite, xPos, yPos, false);
+                squirtGunShots.addToSet(shot);
+            }
         }
     }
     

--- a/public_html/src/MyGame/Objects/Hobbes.js
+++ b/public_html/src/MyGame/Objects/Hobbes.js
@@ -179,7 +179,7 @@ Hobbes.prototype.update = function(
         this.mRightWalking = false;
     }
     // Up arrow key for jump
-    if (gEngine.Input.isKeyClicked(gEngine.Input.keys.W) &&
+    if (gEngine.Input.isKeyClicked(gEngine.Input.keys.Space) &&
         (this.mOnGround || (!this.mOnGround && this.mNumJumps === 1))) {
         var velocity = this.mRigidBodies[0].getVelocity();
         velocity[1] = 45;

--- a/public_html/src/MyGame/Objects/Hobbes.js
+++ b/public_html/src/MyGame/Objects/Hobbes.js
@@ -210,7 +210,7 @@ Hobbes.prototype.update = function(
     }
     
     // Fire squirt gun shots
-    if (gEngine.Input.isKeyClicked(gEngine.Input.keys.Space)) {
+    if (gEngine.Input.isKeyClicked(gEngine.Input.keys.J)) {
         if (this.mFacing === this.eFacing.left) {
             var xPos = this.getXform().getPosition()[0] - 5;
             var yPos = this.getXform().getPosition()[1] +
@@ -230,7 +230,7 @@ Hobbes.prototype.update = function(
     }
     
     // Throw water balloon
-    if (gEngine.Input.isKeyClicked(gEngine.Input.keys.F))   {
+    if (gEngine.Input.isKeyClicked(gEngine.Input.keys.K))   {
         if(this.mHasBalloon) {
             if (this.mFacing === this.eFacing.left) {
                 var xPos = this.getXform().getPosition()[0] - 5;


### PR DESCRIPTION
Based on feedback from the playtesting session, I heard that the keybinds were not ideal and that mashing the spacebar to fire rapidly wasn't great.

This changes the keybinds to:
- WASD movement (W and S do nothing)
- Space to jump
- J to fire squirt gun
- K to throw water balloon

and allows for rapid-fire firing by holding down J.